### PR TITLE
Refresh feedstock

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/msinttypes-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/msinttypes-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/msinttypes-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/msinttypes-feedstock)
+Linux: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/msinttypes-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/msinttypes-feedstock/branch/master)
 
 Current release info
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/msinttypes
 Updating msinttypes-feedstock
 =============================
 
-If you would like to improve the msinttypes recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the msinttypes recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/msinttypes-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,22 +20,8 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_PY: 27
 
     - TARGET_ARCH: x64
-      CONDA_PY: 27
-
-    - TARGET_ARCH: x86
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x86
-      CONDA_PY: 35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 35
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/circle.yml
+++ b/circle.yml
@@ -3,17 +3,7 @@ general:
     ignore:
       - /.*/
 
-machine:
-  services:
-    - docker
-
-dependencies:
-  # Note, we used to use the naive caching of docker images, but found that it was quicker
-  # just to pull each time. #rollondockercaching
-  override:
-    - docker pull condaforge/linux-anvil
-
 test:
   override:
-    # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-    - ./ci_support/run_docker_build.sh
+    # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
+    - exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,11 @@
+{% set version = "r26" %}
 package:
     name: msinttypes
-    version: r26
+    version: {{ version }}
 
 source:
-    url: https://msinttypes.googlecode.com/files/msinttypes-r26.zip
-    fn: msinttypes-r26.zip
+    fn: msinttypes-{{ version }}.zip
+    url: https://msinttypes.googlecode.com/files/msinttypes-{{ version }}.zip
     md5: 94c6acec78be290fc72cd01f2755341a
 
 build:
@@ -14,7 +15,7 @@ build:
 about:
     home: https://code.google.com/archive/p/msinttypes/
     license: BSD-3-Clause
-    summary: ISO C9x compliant stdint.h and inttypes.h for Microsoft Visual Studio
+    summary: 'ISO C9x compliant stdint.h and inttypes.h for Microsoft Visual Studio.'
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
 
 source:
     fn: msinttypes-{{ version }}.zip
-    url: https://msinttypes.googlecode.com/files/msinttypes-{{ version }}.zip
-    md5: 94c6acec78be290fc72cd01f2755341a
+    url: https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/msinttypes/msinttypes-{{ version }}.zip
+    sha256: 6e66d88de18aac0775890e94aa621853aa1d572136e3783ce130510d8fb6a55d
 
 build:
     number: 2


### PR DESCRIPTION
- update URL to google code hosting archive
- rerender
- refreshed recipe

Ping: @mingwandroid I cancelled the builds from #6 b/c the URL was dead. So your build number bump will be this one.
