### PR TITLE
Remove myself from maintainers [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,5 @@ about:
 
 extra:
     recipe-maintainers:
-        - janschulz
         - ocefpaf
         - pelson


### PR DESCRIPTION
I'm currently not using this package and this way the annoying name rename problem is gone.